### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ If you experience problems with Duvet, `log them on GitHub`_. If you
 want to contribute code, please `fork the code`_ and `submit a pull request`_.
 
 .. _BeeWare suite: http://pybee.org
-.. _Read The Docs: http://duvet.readthedocs.org
+.. _Read The Docs: https://duvet.readthedocs.io
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
 .. _BeeWare Users Mailing list: https://groups.google.com/forum/#!forum/beeware-users
 .. _BeeWare Developers Mailing list: https://groups.google.com/forum/#!forum/beeware-developers

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -67,7 +67,7 @@ Duvet is part of the `BeeWare suite`_. You can talk to the community through:
  * The `BeeWare Developers Mailing list`_, for discussing the development of new features in the BeeWare suite, and ideas for new tools for the suite.
 
 .. _BeeWare suite: http://pybee.org
-.. _Read The Docs: http://duvet.readthedocs.org
+.. _Read The Docs: https://duvet.readthedocs.io
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
 .. _BeeWare Users Mailing list: https://groups.google.com/forum/#!forum/beeware-users
 .. _BeeWare Developers Mailing list: https://groups.google.com/forum/#!forum/beeware-developers

--- a/duvet/view.py
+++ b/duvet/view.py
@@ -458,9 +458,9 @@ class MainWindow(object):
         # If this is a formal release, show the docs for that
         # version. otherwise, just show the head docs.
         if len(NUM_VERSION) == 3:
-            webbrowser.open_new('http://duvet.readthedocs.org/en/v%s/' % VERSION)
+            webbrowser.open_new('https://duvet.readthedocs.io/en/v%s/' % VERSION)
         else:
-            webbrowser.open_new('http://duvet.readthedocs.org/')
+            webbrowser.open_new('https://duvet.readthedocs.io/')
 
     def cmd_beeware_page(self):
         "Show the BeeWare project page"


### PR DESCRIPTION
As per their email ‘Changes to project subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.